### PR TITLE
replace assert if isvalid check

### DIFF
--- a/newton-4.00/sdk/dCollision/ndShapeConvexHull.cpp
+++ b/newton-4.00/sdk/dCollision/ndShapeConvexHull.cpp
@@ -62,7 +62,8 @@ class ndShapeConvexHull::ndConvexBox
 		m_vertex = nullptr;
 		m_simplex = nullptr;
 		Create(count, strideInBytes, vertexArray, tolerance, maxPointsOut);
-		ndAssert(m_faceCount > 0);
+		// Degenerate input (coplanar/collinear/duplicated points) leaves
+		// m_faceCount at 0 instead of crashing; callers must check IsValid().
 		ndAssert(ndMemory::CheckMemory(this));
 	}
 
@@ -105,7 +106,8 @@ class ndShapeConvexHull::ndConvexBox
 		ndConvexHull3d* convexHull = new ndConvexHull3d(&buffer[0].m_x, sizeof(ndBigVector), count, tolerance, maxPointsOut);
 		if (!convexHull->GetCount())
 		{
-			ndAssert(0);
+			// Degenerate input (coplanar/collinear/duplicated points); fall
+			// through so the vertexCount < 4 check below returns false.
 			//// this is a degenerated hull, add some thickness and form a thick plane
 			//delete convexHull;
 
@@ -802,7 +804,8 @@ class ndShapeConvexHull::ndConvexBox
 		m_vertex = nullptr;
 		m_simplex = nullptr;
 		Create(count, strideInBytes, vertexArray, tolerance, maxPointsOut);
-		ndAssert(m_faceCount > 0);
+		// Degenerate input (coplanar/collinear/duplicated points) leaves
+		// m_faceCount at 0 instead of crashing; callers must check IsValid().
 	}
 
 	ndShapeConvexHull::~ndShapeConvexHull()
@@ -841,9 +844,10 @@ class ndShapeConvexHull::ndConvexBox
 		}
 
 		ndConvexHull3d* convexHull = new ndConvexHull3d(&buffer[0].m_x, sizeof (ndBigVector), count, tolerance, maxPointsOut);
-		if (!convexHull->GetCount()) 
+		if (!convexHull->GetCount())
 		{
-			ndAssert(0);
+			// Degenerate input (coplanar/collinear/duplicated points); fall
+			// through so the vertexCount < 4 check below returns false.
 			//// this is a degenerated hull, add some thickness and form a thick plane
 			//delete convexHull;
 		

--- a/newton-4.00/sdk/dCollision/ndShapeConvexHull.h
+++ b/newton-4.00/sdk/dCollision/ndShapeConvexHull.h
@@ -38,6 +38,12 @@ class ndShapeConvexHull : public ndShapeConvex
 
 	virtual ndShapeConvexHull* GetAsShapeConvexHull() override { return this; }
 
+	// Returns false when the source points were degenerate (e.g. coplanar,
+	// collinear, or duplicated) and Create() could not build a valid hull.
+	// Callers must check this before using the shape; a degenerate hull has
+	// no vertices/faces and will crash later if used as-is.
+	bool IsValid() const { return m_faceCount > 0; }
+
 	protected:
 	D_COLLISION_API ndShapeInfo GetShapeInfo() const override;
 	D_COLLISION_API ndUnsigned64 GetHash(ndUnsigned64 hash) const override;


### PR DESCRIPTION
Recommendation:

When user creates a convex-hull object, it may be invalid due to coplanar/collinear/duplicated points...

Currently, the engine asserts but it makes it hard to catch that on a general purpose. One can do the checks themselves before but the precision in newton could be different from the manual checks, so I believe relying on newton's checks is the key to consistency. Added an `IsValid()` method to convex body and remove the `assert()`

When one goes about creating a convex body, they can check if collision is valid before doing other things:

For plain convex hulls:
```cpp
ndShapeConvexHull* hull = new ndShapeConvexHull(
    points.size(),
    sizeof(Geom::Vector3),
    tolerance,
    reinterpret_cast<const ndFloat32*>(points.data())
);

if (!hull->IsValid()) {
    // Failed to generate a convex hull collision from input; the geometry is degenerate (e.g. coplanar, collinear, or duplicate points
    delete hull;
    return nullptr;
}
ndShapeInstance* col = new ndShapeInstance(hull);
return col;
```

For compounds:
```cpp
ndShapeConvexHull* hull = new ndShapeConvexHull(
    points.size(),
    sizeof(Geom::Vector3),
    convex_tolerance,
    reinterpret_cast<const ndFloat32*>(points.data())
);
if (hull->IsValid()) {
    ndShapeInstance* col = new ndShapeInstance(hull);
    void* node = col_adder(compound, col);
    delete col;
    col = col_getter(compound, node);
} else {
    delete hull;
}
```